### PR TITLE
[connect-ip] client can also run in kernel mode now via TUN

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,11 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.23.2
 	github.com/MicahParks/jwkset v0.9.5
 	github.com/MicahParks/keyfunc/v3 v3.3.10
+	github.com/adrg/xdg v0.5.3
 	github.com/alphadose/haxmap v1.4.1
+	github.com/anatol/vmtest v0.0.0-20250318022921-2f32244e2f0f
+	github.com/avast/retry-go/v4 v4.6.1
+	github.com/bramvdbogaerde/go-scp v1.5.0
 	github.com/buraksezer/olric v0.5.6
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42
 	github.com/coder/websocket v1.8.12
@@ -38,10 +42,13 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.19.1
 	github.com/google/go-github/v61 v61.0.0
+	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-discover v0.0.0-20240726212017-342faf50e5d4
 	github.com/jedib0t/go-pretty/v6 v6.4.9
 	github.com/k3s-io/kine v0.13.2
+	github.com/kdomanski/iso9660 v0.4.0
+	github.com/klauspost/cpuid/v2 v2.2.10
 	github.com/metal-stack/go-ipam v1.14.7
 	github.com/miekg/dns v1.1.63
 	github.com/mitchellh/mapstructure v1.5.0
@@ -65,6 +72,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1
 	go.temporal.io/api v1.29.2
 	go.temporal.io/sdk v1.26.0
+	golang.org/x/crypto v0.37.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.39.0
 	golang.org/x/sync v0.13.0
@@ -116,21 +124,17 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/Rican7/retry v0.1.0 // indirect
 	github.com/RoaringBitmap/roaring v1.2.1 // indirect
-	github.com/adrg/xdg v0.5.3 // indirect
-	github.com/anatol/vmtest v0.0.0-20250318022921-2f32244e2f0f // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apache/thrift v0.20.0 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
-	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/aws/aws-sdk-go v1.55.5 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/bramvdbogaerde/go-scp v1.5.0 // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c // indirect
 	github.com/cactus/go-statsd-client/v5 v5.1.0 // indirect
@@ -234,10 +238,8 @@ require (
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kdomanski/iso9660 v0.4.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/echo/v4 v4.10.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
@@ -366,7 +368,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/oauth2 v0.29.0 // indirect
 	golang.org/x/term v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
@@ -1258,9 +1260,11 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -1444,6 +1448,7 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/pkg/tunnel/dns/resolver.go
+++ b/pkg/tunnel/dns/resolver.go
@@ -166,7 +166,10 @@ func (r *TunnelNodeDNSReconciler) serveDNS(ctx context.Context, next plugin.Hand
 		return dns.RcodeServerFailure, nil
 	}
 
-	w.WriteMsg(msg)
+	if err := w.WriteMsg(msg); err != nil {
+		log.Error("Failed to write response", slog.Any("error", err))
+		return dns.RcodeServerFailure, err
+	}
 
 	return dns.RcodeSuccess, nil
 }

--- a/pkg/tunnel/net/pcap.go
+++ b/pkg/tunnel/net/pcap.go
@@ -1,0 +1,113 @@
+package net
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+	"golang.zx2c4.com/wireguard/tun"
+)
+
+var _ tun.Device = (*PcapDevice)(nil)
+
+type PcapDevice struct {
+	dev tun.Device
+	w   *pcapgo.Writer
+}
+
+func NewPcapDevice(dev tun.Device, pcapPath string) (*PcapDevice, error) {
+	f, err := os.Create(pcapPath)
+	if err != nil {
+		return nil, err
+	}
+
+	w := pcapgo.NewWriter(f)
+	if err := w.WriteFileHeader(65535, layers.LinkTypeIPv6); err != nil {
+		return nil, err
+	}
+
+	return &PcapDevice{
+		dev: dev,
+		w:   w,
+	}, nil
+}
+
+func (d *PcapDevice) Write(bufs [][]byte, offset int) (int, error) {
+	for _, buf := range bufs {
+		if len(buf) <= offset {
+			slog.Warn("PcapDevice.Write: skipping short buffer",
+				slog.Int("len", len(buf)), slog.Int("offset", offset))
+			continue
+		}
+		packetData := buf[offset:]
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		if err := d.w.WritePacket(ci, packetData); err != nil {
+			return 0, fmt.Errorf("failed to write packet: %w", err)
+		}
+	}
+
+	n, err := d.dev.Write(bufs, offset)
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}
+
+func (d *PcapDevice) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
+	n, err = d.dev.Read(bufs, sizes, offset)
+	if err != nil {
+		return n, err
+	}
+
+	for i := 0; i < n; i++ {
+		if len(bufs[i]) < offset+sizes[i] {
+			slog.Warn("PcapDevice.Read: skipping short buffer",
+				slog.Int("len", len(bufs[i])), slog.Int("offset", offset), slog.Int("size", sizes[i]))
+			continue
+		}
+		packetData := bufs[i][offset : offset+sizes[i]]
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		if err := d.w.WritePacket(ci, packetData); err != nil {
+			return 0, fmt.Errorf("failed to write packet: %w", err)
+		}
+	}
+
+	return n, nil
+}
+
+func (d *PcapDevice) BatchSize() int {
+	return d.dev.BatchSize()
+}
+
+func (d *PcapDevice) Close() error {
+	return d.dev.Close()
+}
+
+func (d *PcapDevice) Events() <-chan tun.Event {
+	return d.dev.Events()
+}
+
+func (d *PcapDevice) File() *os.File {
+	return d.dev.File()
+}
+
+func (d *PcapDevice) MTU() (int, error) {
+	return d.dev.MTU()
+}
+
+func (d *PcapDevice) Name() (string, error) {
+	return d.dev.Name()
+}

--- a/pkg/tunnel/router/netlink.go
+++ b/pkg/tunnel/router/netlink.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package router
+
+import "fmt"
+
+func NewNetlinkRouter(_ ...Option) (Router, error) {
+	return nil, fmt.Errorf("netlink router is not supported on this platform")
+}

--- a/pkg/tunnel/router/options.go
+++ b/pkg/tunnel/router/options.go
@@ -1,0 +1,72 @@
+package router
+
+import (
+	"net/netip"
+
+	"github.com/dpeckett/network"
+)
+
+// Option represents a router configuration option.
+type Option func(*routerOptions)
+
+type routerOptions struct {
+	localAddresses  []netip.Prefix
+	resolveConf     *network.ResolveConfig // If not set system default resolver is used
+	pcapPath        string
+	extIfaceName    string
+	tunIfaceName    string
+	socksListenAddr string
+}
+
+func defaultOptions() *routerOptions {
+	return &routerOptions{
+		extIfaceName:    "eth0",
+		tunIfaceName:    "tun0",
+		socksListenAddr: "localhost:1080",
+	}
+}
+
+// WithLocalAddresses sets the local addresses for the router.
+func WithLocalAddresses(localAddresses []netip.Prefix) Option {
+	return func(o *routerOptions) {
+		o.localAddresses = localAddresses
+	}
+}
+
+// WithPcapPath sets the optional path to a packet capture file for the netstack router.
+func WithPcapPath(path string) Option {
+	return func(o *routerOptions) {
+		o.pcapPath = path
+	}
+}
+
+// WithResolveConfig sets the DNS configuration for the netstack router.
+func WithResolveConfig(conf *network.ResolveConfig) Option {
+	return func(o *routerOptions) {
+		o.resolveConf = conf
+	}
+}
+
+// WithExternalInterface sets the external interface name.
+// Only valid for netlink routers.
+func WithExternalInterface(name string) Option {
+	return func(o *routerOptions) {
+		o.extIfaceName = name
+	}
+}
+
+// WithTunnelInterface sets the tunnel interface name.
+// Only valid for netlink routers.
+func WithTunnelInterface(name string) Option {
+	return func(o *routerOptions) {
+		o.tunIfaceName = name
+	}
+}
+
+// WithSocksListenAddr sets the SOCKS listen address for the netstack router.
+// Only valid for netstack routers.
+func WithSocksListenAddr(addr string) Option {
+	return func(o *routerOptions) {
+		o.socksListenAddr = addr
+	}
+}

--- a/pkg/tunnel/router/router.go
+++ b/pkg/tunnel/router/router.go
@@ -22,4 +22,7 @@ type Router interface {
 
 	// RemovePeer removes a peer route from the tunnel identified by the given prefix.
 	RemovePeer(peer netip.Prefix) error
+
+	// LocalAddresses returns the list of local addresses that are assigned to the router.
+	LocalAddresses() ([]netip.Prefix, error)
 }

--- a/pkg/tunnel/token/jwks.go
+++ b/pkg/tunnel/token/jwks.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"fmt"
@@ -37,7 +38,7 @@ func NewJWKSHandler(publicKeyPEM []byte) (http.HandlerFunc, error) {
 	}
 
 	jwkSet := jwkset.NewMemoryStorage()
-	if err := jwkSet.KeyWrite(nil, jwk); err != nil {
+	if err := jwkSet.KeyWrite(context.Background(), jwk); err != nil {
 		return nil, fmt.Errorf("failed to write JWK: %w", err)
 	}
 

--- a/pkg/tunnel/tunnel_test.go
+++ b/pkg/tunnel/tunnel_test.go
@@ -10,10 +10,12 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -30,9 +32,15 @@ import (
 	"github.com/apoxy-dev/apoxy-cli/pkg/tunnel"
 	"github.com/apoxy-dev/apoxy-cli/pkg/tunnel/router"
 	"github.com/apoxy-dev/apoxy-cli/pkg/tunnel/token"
+	"github.com/apoxy-dev/apoxy-cli/pkg/utils/vm"
 )
 
-func TestTunnelEndToEnd(t *testing.T) {
+func TestTunnelEndToEnd_UserModeClient(t *testing.T) {
+	child := vm.RunTestInVM(t)
+	if !child {
+		return
+	}
+
 	if testing.Verbose() {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
@@ -88,16 +96,13 @@ func TestTunnelEndToEnd(t *testing.T) {
 	jwtValidator, err := token.NewInMemoryValidator(jwtPublicKeyPEM)
 	require.NoError(t, err)
 
-	netstackRouter, err := router.NewNetstackRouter(
-		router.WithSocksListenAddr("localhost:1080"),
-		router.WithPcapPath("server.pcap"),
-	)
+	serverRouter, err := router.NewNetlinkRouter()
 	require.NoError(t, err)
 
 	server := tunnel.NewTunnelServer(
 		kubeClient,
 		jwtValidator,
-		netstackRouter,
+		serverRouter,
 		tunnel.WithCertPath(filepath.Join(certsDir, "server.crt")),
 		tunnel.WithKeyPath(filepath.Join(certsDir, "server.key")),
 	)
@@ -115,11 +120,9 @@ func TestTunnelEndToEnd(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	gCtx, gCancel := context.WithCancel(ctx)
-	t.Cleanup(gCancel)
-	g, gctx := errgroup.WithContext(gCtx)
+	g, ctx := errgroup.WithContext(ctx)
 
-	// Start a little http server listening on localhost (to test the tunnel)
+	// Start a little http server listening on the client side.
 	httpListener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
@@ -133,7 +136,7 @@ func TestTunnelEndToEnd(t *testing.T) {
 
 	g.Go(func() error {
 		g.Go(func() error {
-			<-gctx.Done()
+			<-ctx.Done()
 			t.Log("Closing HTTP test server")
 			return httpServer.Close()
 		})
@@ -154,7 +157,7 @@ func TestTunnelEndToEnd(t *testing.T) {
 
 		t.Log("Starting tunnel server")
 
-		if err := server.Start(gctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("unable to start server: %v", err)
 		}
 
@@ -165,28 +168,269 @@ func TestTunnelEndToEnd(t *testing.T) {
 	g.Go(func() error {
 		defer t.Log("Tunnel client closed")
 
-		defer gCancel() // Abort everything when the client is done
-
 		// Wait for the server to start
 		time.Sleep(1 * time.Second)
 
 		t.Log("Starting tunnel client")
 
-		if err := client.Start(gCtx); err != nil {
+		if err := client.Start(ctx); err != nil {
 			return fmt.Errorf("unable to connect to server: %v", err)
 		}
 		defer func() {
 			_ = client.Close()
 		}()
 
-		clientAddresses, err := client.LocalAddresses()
+		return nil
+	})
+
+	// Run the test
+	g.Go(func() error {
+		// Cancel the context when the test is done
+		defer cancel()
+
+		var clientAddresses []netip.Prefix
+		err := retry.Do(
+			func() error {
+				var err error
+				clientAddresses, err = client.LocalAddresses()
+				if err != nil {
+					return err
+				}
+				if len(clientAddresses) == 0 {
+					return fmt.Errorf("no addresses yet")
+				}
+				return nil
+			},
+			retry.Context(ctx),
+			retry.Attempts(10),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
-			return fmt.Errorf("unable to get local addresses: %v", err)
+			return fmt.Errorf("failed to get client addresses: %w", err)
 		}
 
 		t.Logf("Assigned client addresses: %v", clientAddresses)
 
-		// Connect to the netstack routers / servers socks5 proxy
+		t.Log("Connecting to HTTP server running on client via the tunnel")
+
+		httpPort := httpListener.Addr().(*net.TCPAddr).Port
+		resp, err := http.Get("http://" + net.JoinHostPort(clientAddresses[0].Addr().String(), fmt.Sprintf("%d", httpPort)))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Read the response body
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "Hello, world!\n", string(body))
+
+		t.Log("Connection successful")
+
+		return nil
+	})
+
+	require.NoError(t, g.Wait())
+}
+
+func TestTunnelEndToEnd_KernelModeClient(t *testing.T) {
+	child := vm.RunTestInVM(t)
+	if !child {
+		return
+	}
+
+	if testing.Verbose() {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	caCert, serverCert, err := cryptoutils.GenerateSelfSignedTLSCert("localhost")
+	require.NoError(t, err)
+
+	certsDir := t.TempDir()
+
+	// Save the server certificate and private key to the temporary directory as PEM files
+	err = cryptoutils.SaveCertificatePEM(serverCert, certsDir, "server", false)
+	require.NoError(t, err)
+
+	// Create a client UUID and JWT token
+	// This UUID is used to identify the client in the server's tunnel node list.
+	// The JWT token is used for authentication and contains the client's UUID as the subject.
+	clientUUID := uuid.New()
+
+	jwtPrivateKeyPEM, jwtPublicKeyPEM, err := cryptoutils.GenerateEllipticKeyPair()
+	require.NoError(t, err)
+
+	jwtPrivateKey, err := cryptoutils.ParseEllipticPrivateKeyPEM(jwtPrivateKeyPEM)
+	require.NoError(t, err)
+
+	clientAuthToken, err := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"sub": clientUUID.String(),
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Minute * 5).Unix(),
+	}).SignedString(jwtPrivateKey)
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha.Install(scheme))
+
+	clientTunnelNode := &corev1alpha.TunnelNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "client",
+			UID:  apimachinerytypes.UID(clientUUID.String()),
+		},
+		Status: corev1alpha.TunnelNodeStatus{
+			Credentials: &corev1alpha.TunnelNodeCredentials{
+				Token: clientAuthToken,
+			},
+		},
+	}
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(clientTunnelNode).WithStatusSubresource(clientTunnelNode).Build()
+
+	jwtValidator, err := token.NewInMemoryValidator(jwtPublicKeyPEM)
+	require.NoError(t, err)
+
+	serverRouter, err := router.NewNetstackRouter(
+		// We need to assign atleast one local address to the server for netstack to work.
+		router.WithLocalAddresses([]netip.Prefix{
+			netip.MustParsePrefix("fd00::/64"),
+		}),
+		router.WithPcapPath("server.pcap"),
+	)
+	require.NoError(t, err)
+
+	server := tunnel.NewTunnelServer(
+		kubeClient,
+		jwtValidator,
+		serverRouter,
+		tunnel.WithCertPath(filepath.Join(certsDir, "server.crt")),
+		tunnel.WithKeyPath(filepath.Join(certsDir, "server.key")),
+	)
+
+	// Register the client with the server
+	server.AddTunnelNode(clientTunnelNode)
+
+	// Create a new tunnel client
+	client, err := tunnel.NewTunnelClient(
+		tunnel.WithUUID(clientUUID),
+		tunnel.WithAuthToken(clientAuthToken),
+		tunnel.WithRootCAs(cryptoutils.CertPoolForCertificate(caCert)),
+		tunnel.WithMode(tunnel.TunnelClientModeKernel),
+		tunnel.WithPcapPath("client.pcap"),
+	)
+	require.NoError(t, err)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Start the server
+	g.Go(func() error {
+		defer t.Log("Tunnel server closed")
+
+		t.Log("Starting tunnel server")
+
+		if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("unable to start server: %v", err)
+		}
+
+		return nil
+	})
+
+	// Start the client
+	g.Go(func() error {
+		defer t.Log("Tunnel client closed")
+
+		// Wait for the server to start
+		time.Sleep(1 * time.Second)
+
+		t.Log("Starting tunnel client")
+
+		if err := client.Start(ctx); err != nil {
+			return fmt.Errorf("unable to connect to server: %v", err)
+		}
+		defer func() {
+			_ = client.Close()
+		}()
+
+		return nil
+	})
+
+	var httpListener net.Listener
+	g.Go(func() error {
+		var clientAddresses []netip.Prefix
+		err := retry.Do(
+			func() error {
+				var err error
+				clientAddresses, err = client.LocalAddresses()
+				if err != nil {
+					return err
+				}
+				if len(clientAddresses) == 0 {
+					return fmt.Errorf("no addresses yet")
+				}
+				return nil
+			},
+			retry.Context(ctx),
+			retry.Attempts(10),
+			retry.Delay(time.Second),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to get client addresses: %w", err)
+		}
+
+		// Start a little http server listening on the client side.
+		httpListener, err = net.Listen("tcp", net.JoinHostPort(clientAddresses[0].Addr().String(), "0"))
+		require.NoError(t, err)
+
+		httpServer := &http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, "Hello, world!")
+			}),
+		}
+
+		g.Go(func() error {
+			<-ctx.Done()
+			t.Log("Closing HTTP test server")
+			return httpServer.Close()
+		})
+
+		defer t.Log("HTTP test server closed")
+		t.Log("Starting HTTP test server")
+
+		if err := httpServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("unable to start HTTP server: %v", err)
+		}
+
+		return nil
+	})
+
+	g.Go(func() error {
+		// Cancel the context when the test is done
+		defer cancel()
+
+		err := retry.Do(
+			func() error {
+				if httpListener == nil {
+					return fmt.Errorf("http listener not ready")
+				}
+				return nil
+			},
+			retry.Context(ctx),
+			retry.Attempts(10),
+			retry.Delay(1*time.Second),
+		)
+		if err != nil {
+			return fmt.Errorf("listener never became ready: %w", err)
+		}
+
+		t.Logf("Connecting to HTTP server running on client via the tunnel: %s",
+			httpListener.Addr().(*net.TCPAddr).String())
+
 		dialer, err := proxyclient.SOCKS5("tcp", "localhost:1080", nil, proxyclient.Direct)
 		require.NoError(t, err)
 
@@ -196,10 +440,7 @@ func TestTunnelEndToEnd(t *testing.T) {
 			},
 		}
 
-		t.Log("Connecting to HTTP server through server SOCKS5 proxy")
-
-		httpPort := httpListener.Addr().(*net.TCPAddr).Port
-		resp, err := client.Get("http://" + net.JoinHostPort(clientAddresses[0].Addr().String(), fmt.Sprintf("%d", httpPort)))
+		resp, err := client.Get("http://" + httpListener.Addr().(*net.TCPAddr).String())
 		require.NoError(t, err)
 		defer resp.Body.Close()
 


### PR DESCRIPTION
During performance testing I don't want to be pushing everything through netstack & socks (naturally that won't be particularly impressive).

Also added packet capturing capabilities for TUN devices.