### PR TITLE
[tun] implement basic multiqueue tun interface

### DIFF
--- a/pkg/tunnel/connection/pipe_test.go
+++ b/pkg/tunnel/connection/pipe_test.go
@@ -2,46 +2,73 @@ package connection_test
 
 import (
 	"bytes"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/apoxy-dev/apoxy-cli/pkg/netstack"
 	"github.com/apoxy-dev/apoxy-cli/pkg/tunnel/connection"
 )
 
 func TestPipeThroughput(t *testing.T) {
 	const (
-		packetSize = 1024      // 1 KB per packet
-		numPackets = 1_000_000 // Total packets to send
+		packetSize = netstack.IPv6MinMTU
+		numPackets = 10_000_000
 	)
 
-	p1, p2 := connection.NewPipe(t.Context())
+	p1, p2 := connection.NewPipe(t.Context(), packetSize)
 
 	payload := bytes.Repeat([]byte("X"), packetSize)
 	buf := make([]byte, packetSize)
 
-	done := make(chan struct{})
+	var bytesTransferred int64
+	var packetsTransferred int64
 
+	// Reader goroutine
 	go func() {
 		for i := 0; i < numPackets; i++ {
 			if _, err := p2.ReadPacket(buf); err != nil {
-				t.Fatal(err)
+				select {
+				case <-t.Context().Done():
+				default:
+					t.Fatalf("Read error: %v", err)
+				}
+				return
 			}
+			atomic.AddInt64(&bytesTransferred, int64(packetSize))
+			atomic.AddInt64(&packetsTransferred, 1)
 		}
-		close(done)
 	}()
+
+	// Reporter goroutine
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	go func(startTime time.Time) {
+		lastTransferred := int64(0)
+		for range ticker.C {
+			currentTransferred := atomic.LoadInt64(&bytesTransferred)
+			bytesThisSecond := currentTransferred - lastTransferred
+			lastTransferred = currentTransferred
+
+			throughputGbps := (float64(bytesThisSecond*8) / 1e9)
+			elapsed := time.Since(startTime).Truncate(time.Second)
+			t.Logf("[+%s] Throughput: %.2f Gbps", elapsed, throughputGbps)
+			t.Logf("[+%s] Packets: %d", elapsed, atomic.LoadInt64(&packetsTransferred))
+		}
+	}(time.Now())
 
 	start := time.Now()
 
+	// Writer loop
 	for i := 0; i < numPackets; i++ {
 		if _, err := p1.WritePacket(payload); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	<-done
 	duration := time.Since(start)
 
-	throughputGbps := (float64(packetSize*numPackets*8) / 1e9) / duration.Seconds()
-	t.Logf("Sent %d packets of %d bytes in %s", numPackets, packetSize, duration)
-	t.Logf("Throughput: %.2f Gbps", throughputGbps)
+	totalThroughputGbps := (float64(packetSize*numPackets*8) / 1e9) / duration.Seconds()
+	t.Logf("Total Throughput: %.2f Gbps", totalThroughputGbps)
 }

--- a/pkg/tunnel/fasttun/fasttun.go
+++ b/pkg/tunnel/fasttun/fasttun.go
@@ -1,0 +1,44 @@
+// Package fasttun implements a high-performance interface to Linux TUN devices
+// with support for multi-queue and batched packet I/O.
+package fasttun
+
+import "io"
+
+// Device represents a virtual TUN network interface.
+// It provides methods to query device properties and create packet queues
+// for reading and writing packets concurrently.
+type Device interface {
+	io.Closer
+
+	// Name returns the name of the TUN device (e.g., "tun0").
+	Name() string
+
+	// MTU returns the device's Maximum Transmission Unit.
+	MTU() (int, error)
+
+	// BatchSize returns the recommended number of packets to process in one batch.
+	// This is useful for optimizing I/O performance.
+	BatchSize() int
+
+	// NewPacketQueue creates a new packet queue for the device.
+	// Each queue is associated with a file descriptor and can be used
+	// concurrently with others.
+	NewPacketQueue() (PacketQueue, error)
+}
+
+// PacketQueue represents a single queue for sending and receiving packets
+// from a TUN device. It supports batch I/O for efficient packet processing.
+type PacketQueue interface {
+	io.Closer
+
+	// Read reads packets into the provided buffer slices `pkts` and stores
+	// the size of each packet in `sizes`.
+	//
+	// It returns the number of packets successfully read and an error, if any.
+	// On timeout or no available packets, it may return (0, nil).
+	Read(pkts [][]byte, sizes []int) (n int, err error)
+
+	// Write writes the given packets to the TUN device.
+	// It returns the number of packets successfully written and an error, if any.
+	Write(pkts [][]byte) (int, error)
+}

--- a/pkg/tunnel/fasttun/fasttun_linux.go
+++ b/pkg/tunnel/fasttun/fasttun_linux.go
@@ -1,0 +1,195 @@
+//go:build linux
+
+package fasttun
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+var _ Device = (*LinuxDevice)(nil)
+
+type LinuxDevice struct {
+	name              string
+	mtu               int
+	packetQueuesMu    sync.Mutex
+	packetQueues      []*LinuxPacketQueue
+	configureLinkOnce sync.Once
+}
+
+// NewDevice creates a new Linux TUN device with the given name and MTU.
+// Initialization of the device is deferred until the first packet queue is created.
+func NewDevice(name string, mtu int) *LinuxDevice {
+	return &LinuxDevice{
+		name: name,
+		mtu:  mtu,
+	}
+}
+
+func (d *LinuxDevice) Close() error {
+	d.packetQueuesMu.Lock()
+	defer d.packetQueuesMu.Unlock()
+
+	var closeErr error
+	for _, q := range d.packetQueues {
+		if err := q.Close(); err != nil && closeErr == nil {
+			closeErr = err // capture the first error
+		}
+	}
+	d.packetQueues = nil
+
+	return fmt.Errorf("failed to close packet queues: %w", closeErr)
+}
+
+func (d *LinuxDevice) Name() string {
+	return d.name
+}
+
+func (d *LinuxDevice) MTU() (int, error) {
+	return d.mtu, nil
+}
+
+func (d *LinuxDevice) BatchSize() int {
+	return 64
+}
+
+// NewPacketQueue creates a new packet queue for the device.
+func (d *LinuxDevice) NewPacketQueue() (PacketQueue, error) {
+	fd, err := unix.Open("/dev/net/tun", unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open /dev/net/tun: %w", err)
+	}
+
+	ifr, err := unix.NewIfreq(d.name)
+	if err != nil {
+		return nil, err
+	}
+
+	ifr.SetUint16(unix.IFF_TUN | unix.IFF_NO_PI | unix.IFF_MULTI_QUEUE)
+	if err := unix.IoctlIfreq(fd, unix.TUNSETIFF, ifr); err != nil {
+		return nil, err
+	}
+
+	if err := unix.SetNonblock(fd, true); err != nil {
+		unix.Close(fd)
+		return nil, err
+	}
+
+	tunFile := os.NewFile(uintptr(fd), "/dev/net/tun")
+
+	q := &LinuxPacketQueue{
+		tunFile: tunFile,
+	}
+
+	// Store a reference to the packet queue.
+	d.packetQueuesMu.Lock()
+	d.packetQueues = append(d.packetQueues, q)
+	d.packetQueuesMu.Unlock()
+
+	d.configureLinkOnce.Do(func() {
+		link, err := netlink.LinkByName(d.name)
+		if err != nil {
+			err = fmt.Errorf("failed to get link by name: %w", err)
+		}
+
+		if err := netlink.LinkSetMTU(link, d.mtu); err != nil {
+			err = fmt.Errorf("failed to set MTU: %w", err)
+		}
+
+		if err := netlink.LinkSetUp(link); err != nil {
+			err = fmt.Errorf("failed to set link up: %w", err)
+		}
+	})
+	if err != nil {
+		_ = q.Close()
+		return nil, fmt.Errorf("failed to configure link: %w", err)
+	}
+
+	return q, nil
+}
+
+type LinuxPacketQueue struct {
+	tunFile *os.File
+}
+
+func (q *LinuxPacketQueue) Close() error {
+	return q.tunFile.Close()
+}
+
+func (q *LinuxPacketQueue) Read(pkts [][]byte, sizes []int) (int, error) {
+	fd := int(q.tunFile.Fd())
+	timeout := 50 * time.Millisecond
+
+	pollFds := []unix.PollFd{
+		{
+			Fd:     int32(fd),
+			Events: unix.POLLIN,
+		},
+	}
+
+	n := 0
+	for i := 0; i < len(pkts); i++ {
+		if i == 0 {
+			// Wait for initial packet or timeout
+			nReady, err := pollWithRetry(pollFds, int(timeout.Milliseconds()))
+			if err != nil {
+				return 0, fmt.Errorf("poll error: %w", err)
+			}
+			if nReady == 0 {
+				return 0, nil // timeout, no packets available
+			}
+		} else {
+			// Check if more data is immediately ready
+			pollFds[0].Events = unix.POLLIN
+			pollFds[0].Revents = 0
+			nReady, err := pollWithRetry(pollFds, 0)
+			if err != nil {
+				return n, fmt.Errorf("poll error during batching: %w", err)
+			}
+			if nReady == 0 {
+				break // no more packets ready
+			}
+		}
+
+		buf := pkts[i]
+		nRead, err := q.tunFile.Read(buf)
+		if err != nil {
+			if n == 0 {
+				return 0, err
+			}
+			return n, nil // return packets read so far
+		}
+		sizes[i] = nRead
+		n++
+	}
+
+	return n, nil
+}
+
+func (q *LinuxPacketQueue) Write(pkts [][]byte) (int, error) {
+	for i, pkt := range pkts {
+		_, err := q.tunFile.Write(pkt)
+		if err != nil {
+			if i == 0 {
+				return 0, err
+			}
+			return i, nil
+		}
+	}
+	return len(pkts), nil
+}
+
+func pollWithRetry(pollFds []unix.PollFd, timeout int) (int, error) {
+	for {
+		n, err := unix.Poll(pollFds, timeout)
+		if err == unix.EINTR {
+			continue // retry on EINTR
+		}
+		return n, err
+	}
+}


### PR DESCRIPTION
Still need to implement all the available offloading features, we're probably leaving quite a bit of performance on the table. If we are careful we might be able to crack an aggregate of around 20gbit/s but each flow will individually limited to ~2-3gbit/s.

Perf testing of two TUN interfaces on a `c7g.metal` ec2 box. peaks at around 15gbit/s

```
$ iperf3 -V -C cubic -c fd00::1 -t 10 -P 32
- - - - - - - - - - - - - - - - - - - - - - - - -
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  1.03 GBytes   881 Mbits/sec  38609            sender
[  5]   0.00-10.00  sec  1.02 GBytes   880 Mbits/sec                  receiver
[  7]   0.00-10.00  sec  1.06 GBytes   912 Mbits/sec  42119            sender
[  7]   0.00-10.00  sec  1.06 GBytes   910 Mbits/sec                  receiver
[  9]   0.00-10.00  sec  1.06 GBytes   914 Mbits/sec  41085            sender
[  9]   0.00-10.00  sec  1.06 GBytes   914 Mbits/sec                  receiver
[ 11]   0.00-10.00  sec  1.08 GBytes   930 Mbits/sec  41365            sender
[ 11]   0.00-10.00  sec  1.08 GBytes   930 Mbits/sec                  receiver
[ 13]   0.00-10.00  sec  1.07 GBytes   923 Mbits/sec  41974            sender
[ 13]   0.00-10.00  sec  1.07 GBytes   922 Mbits/sec                  receiver
[ 15]   0.00-10.00  sec  1.08 GBytes   931 Mbits/sec  41364            sender
[ 15]   0.00-10.00  sec  1.08 GBytes   930 Mbits/sec                  receiver
[ 17]   0.00-10.00  sec  1.09 GBytes   936 Mbits/sec  41629            sender
[ 17]   0.00-10.00  sec  1.09 GBytes   935 Mbits/sec                  receiver
[ 19]   0.00-10.00  sec  1.06 GBytes   908 Mbits/sec  40729            sender
[ 19]   0.00-10.00  sec  1.06 GBytes   907 Mbits/sec                  receiver
[ 21]   0.00-10.00  sec  1016 MBytes   852 Mbits/sec  39958            sender
[ 21]   0.00-10.00  sec  1015 MBytes   851 Mbits/sec                  receiver
[ 23]   0.00-10.00  sec  1.04 GBytes   897 Mbits/sec  40635            sender
[ 23]   0.00-10.00  sec  1.04 GBytes   896 Mbits/sec                  receiver
[ 25]   0.00-10.00  sec  1001 MBytes   840 Mbits/sec  37889            sender
[ 25]   0.00-10.00  sec  1000 MBytes   839 Mbits/sec                  receiver
[ 27]   0.00-10.00  sec  1.08 GBytes   932 Mbits/sec  41773            sender
[ 27]   0.00-10.00  sec  1.08 GBytes   931 Mbits/sec                  receiver
[ 29]   0.00-10.00  sec  1.03 GBytes   887 Mbits/sec  40003            sender
[ 29]   0.00-10.00  sec  1.03 GBytes   887 Mbits/sec                  receiver
[ 31]   0.00-10.00  sec  1.09 GBytes   933 Mbits/sec  42185            sender
[ 31]   0.00-10.00  sec  1.09 GBytes   932 Mbits/sec                  receiver
[ 33]   0.00-10.00  sec  1.06 GBytes   907 Mbits/sec  40702            sender
[ 33]   0.00-10.00  sec  1.06 GBytes   907 Mbits/sec                  receiver
[ 35]   0.00-10.00  sec   984 MBytes   825 Mbits/sec  37595            sender
[ 35]   0.00-10.00  sec   983 MBytes   824 Mbits/sec                  receiver
[SUM]   0.00-10.00  sec  16.8 GBytes  14.4 Gbits/sec  649614             sender
[SUM]   0.00-10.00  sec  16.8 GBytes  14.4 Gbits/sec                  receiver
CPU Utilization: local/sender 38.6% (0.6%u/38.0%s), remote/receiver 227.3% (4.2%u/223.1%s)
```

We're probably being in part limited by the single queue `connection.Pipe()` implementation, notably slower on the graviton than my personal laptop.

```
=== RUN   TestPipeThroughput
    pipe_test.go:56: [+1s] Throughput: 23.08 Gbps
    pipe_test.go:57: [+1s] Packets: 2254273
    pipe_test.go:56: [+2s] Throughput: 23.15 Gbps
    pipe_test.go:57: [+2s] Packets: 4515376
    pipe_test.go:56: [+3s] Throughput: 22.67 Gbps
    pipe_test.go:57: [+3s] Packets: 6728834
    pipe_test.go:56: [+4s] Throughput: 22.68 Gbps
    pipe_test.go:57: [+4s] Packets: 8943763
    pipe_test.go:73: Total Throughput: 22.89 Gbps
--- PASS: TestPipeThroughput (4.47s)
PASS
```

Also I'd try to avoid `TUNSETSTEERINGEBPF`, if we can get the application to use the same sending queue for each flow we don't need to worry too much about steering. Might get a little tricky but doing this in userspace might be doable?